### PR TITLE
Update Scala Native 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 cache:
   directories:
     - $HOME/.cache/coursier/v1
-    - $HOME/.cache/coverage
+    - $HOME/.cache/codacy
     - $HOME/.sbt/boot
 before_cache:
   - find $HOME/.sbt -name "*.lock" -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
+os: linux
+dist: bionic
 language: scala
-sudo: required
-dist: trusty
-scala:
-  - 2.13.3
 jdk:
-  - oraclejdk8
-before_script:
-  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+  - openjdk8
 script:
-  - sbt +clean +reactifyJVM/test +reactifyJS/test ++2.11.12 reactifyNative/test
+  - sbt +clean +reactifyJVM/test +reactifyJS/test +reactifyNative/test
   - sbt coverage reactifyJVM/test
-  - sbt coverageReport
   - sbt coverageAggregate
-  - sbt codacyCoverage
+  - bash <(curl -Ls https://coverage.codacy.com/get.sh) report --skip
 cache:
   directories:
-    - $HOME/.ivy2/cache
+    - $HOME/.cache/coursier/v1
+    - $HOME/.cache/coverage
     - $HOME/.sbt/boot
 before_cache:
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ val scala211 = "2.11.12"
 val scala3 = "3.0.0-M3"
 val allScalaVersions = List(scala213, scala212, scala211, scala3)
 val scala2Versions = List(scala213, scala212, scala211)
-val nativeScalaVersions = List(scala211)
 
 name in ThisBuild := "reactify"
 organization in ThisBuild := "com.outr"
@@ -31,7 +30,7 @@ developers in ThisBuild := List(
   Developer(id="darkfrog", name="Matt Hicks", email="matt@matthicks.", url=url("http://matthicks.com"))
 )
 
-val scalatestVersion = "3.2.3"
+val scalatestVersion = "3.2.4-M1"
 
 lazy val reactify = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -39,22 +38,12 @@ lazy val reactify = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "reactify",
     publishArtifact in Test := false
   )
-  .nativeSettings(
-    nativeLinkStubs := true,
-    scalaVersion := "2.11.12",
-    crossScalaVersions := nativeScalaVersions,
+  .platformsSettings(JVMPlatform, NativePlatform)(
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
-    )
-  )
-  .jvmSettings(
-    crossScalaVersions := allScalaVersions,
-    libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     )
   )
   .jsSettings(
-    crossScalaVersions := allScalaVersions,
     test in Test := {},         // Temporary work-around for ScalaTest not working with Scala.js on Dotty
     libraryDependencies ++= (
       if (isDotty.value) {      // Temporary work-around for ScalaTest not working with Scala.js on Dotty
@@ -64,10 +53,9 @@ lazy val reactify = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       }
     )
   )
-
-lazy val reactifyJVM = reactify.jvm
-lazy val reactifyJS = reactify.js
-lazy val reactifyNative = reactify.native
+  .nativeSettings(
+    crossScalaVersions := scala2Versions,
+  )
 
 //lazy val benchmark = project
 //  .in(file("benchmark"))

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 // Scala versions
 val scala213 = "2.13.4"
-val scala212 = "2.12.12"
+val scala212 = "2.12.13"
 val scala211 = "2.11.12"
 val scala3 = "3.0.0-M3"
 val allScalaVersions = List(scala213, scala212, scala211, scala3)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "3.0.3")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.3.1")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0-M2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")


### PR DESCRIPTION
- Remove travis deprecations
- Update travis distro to bionic ( we need at least Clang 6 )
- Update Scalatest to 3.2.4-M1
- Update Codacy Coverage to use the official bash script
- Avoid running coverageReport since it's not needed from sbt-scoverage 1.6